### PR TITLE
opera-proxy: update binary file and removing arguments from the code in an application

### DIFF
--- a/application/app/src/main/java/com/android/zdtd/service/ui/ProgramScreen.kt
+++ b/application/app/src/main/java/com/android/zdtd/service/ui/ProgramScreen.kt
@@ -122,7 +122,7 @@ fun ProgramScreen(
     }
 
     when {
-      
+
 isProfileProgramType(program.type) -> {
         item {
           if (hasStrategicFiles) {
@@ -1481,6 +1481,7 @@ private fun OperaProxySection(actions: ZdtdActions, snackHost: SnackbarHostState
         Tab(selected = tab == 1, onClick = { tab = 1 }, text = { Text(stringResource(R.string.tab_byedpi), maxLines = 2) })
         Tab(selected = tab == 2, onClick = { tab = 2 }, text = { Text(stringResource(R.string.tab_sni), maxLines = 2) })
         Tab(selected = tab == 3, onClick = { tab = 3 }, text = { Text(stringResource(R.string.tab_servers), maxLines = 2) })
+        Tab(selected = tab == 4, onClick = { tab = 4 }, text = { Text(stringResource(R.string.tab_opera_args), maxLines = 2) })
       }
     } else {
       TabRow(selectedTabIndex = tab) {
@@ -1488,6 +1489,7 @@ private fun OperaProxySection(actions: ZdtdActions, snackHost: SnackbarHostState
         Tab(selected = tab == 1, onClick = { tab = 1 }, text = { Text(stringResource(R.string.tab_byedpi), maxLines = 2) })
         Tab(selected = tab == 2, onClick = { tab = 2 }, text = { Text(stringResource(R.string.tab_sni), maxLines = 2) })
         Tab(selected = tab == 3, onClick = { tab = 3 }, text = { Text(stringResource(R.string.tab_servers), maxLines = 2) })
+        Tab(selected = tab == 4, onClick = { tab = 4 }, text = { Text(stringResource(R.string.tab_opera_args), maxLines = 2) })
       }
     }
 
@@ -1530,6 +1532,9 @@ private fun OperaProxySection(actions: ZdtdActions, snackHost: SnackbarHostState
       }
       3 -> {
         OperaServerSection(actions = actions, snack = ::snack)
+      }
+      4 -> {
+        OperaArgsSection(actions = actions, snackHost = snackHost)
       }
     }
   }
@@ -2042,6 +2047,361 @@ private fun OperaServerSection(
         )
       }
     }
+  }
+}
+
+
+@Composable
+private fun OperaArgsSection(actions: ZdtdActions, snackHost: SnackbarHostState) {
+  val apiPath = "/api/programs/operaproxy/args"
+  val scope = rememberCoroutineScope()
+  val context = LocalContext.current
+  fun snack(msg: String) { scope.launch { snackHost.showSnackbar(msg) } }
+
+  val dnsApiPath = "/api/programs/operaproxy/bootstrap_dns"
+
+  // State for each OperaArgs field (mirrors the Rust struct)
+  var apiProxy        by remember { mutableStateOf("") }
+  var apiUserAgent    by remember { mutableStateOf("") }
+  var initRetry       by remember { mutableStateOf("") }
+  var serverSelection by remember { mutableStateOf("fastest") }
+  var dlLimit         by remember { mutableStateOf("") }
+  var testUrl         by remember { mutableStateOf("") }
+  var verbosity       by remember { mutableStateOf("") }
+  var loaded          by remember { mutableStateOf(false) }
+  var saving          by remember { mutableStateOf(false) }
+
+  // Bootstrap DNS: list of resolver URL strings
+  var dnsResolvers    by remember { mutableStateOf(listOf<String>()) }
+  var dnsLoaded       by remember { mutableStateOf(false) }
+  var dnsSaving       by remember { mutableStateOf(false) }
+  // New resolver input field
+  var dnsNewEntry     by remember { mutableStateOf("") }
+
+  // Load current args from daemon on first compose
+  LaunchedEffect(Unit) {
+    actions.loadJsonData(apiPath) { obj ->
+      if (obj != null) {
+        apiProxy        = obj.optString("api_proxy",                 "socks5://193.221.203.192:1080")
+        apiUserAgent    = obj.optString("api_user_agent",            "")
+        initRetry       = obj.optString("init_retry_interval",       "3s")
+        serverSelection = obj.optString("server_selection",          "fastest")
+        dlLimit         = obj.optLong("server_selection_dl_limit",   204800L).toString()
+        testUrl         = obj.optString("server_selection_test_url", "https://ajax.googleapis.com/ajax/libs/angularjs/1.8.2/angular.min.js")
+        verbosity       = obj.optInt("verbosity",                    50).toString()
+      }
+      loaded = true
+    }
+    // Load bootstrap DNS resolvers list
+    actions.loadJsonData(dnsApiPath) { obj ->
+      if (obj != null) {
+        val arr = obj.optJSONArray("data") ?: obj.optJSONArray("resolvers")
+        if (arr != null) {
+          dnsResolvers = (0 until arr.length()).mapNotNull { i ->
+            arr.optString(i).trim().takeIf { it.isNotEmpty() }
+          }
+        }
+      }
+      // If still empty after load, show defaults hint via empty list
+      dnsLoaded = true
+    }
+  }
+
+  fun save() {
+    val obj = JSONObject().apply {
+      put("api_proxy",                    apiProxy.trim())
+      put("api_user_agent",               apiUserAgent.trim())
+      put("init_retry_interval",          initRetry.trim())
+      put("server_selection",             serverSelection.trim())
+      put("server_selection_dl_limit",    dlLimit.trim().toLongOrNull() ?: 204800L)
+      put("server_selection_test_url",    testUrl.trim())
+      put("verbosity",                    verbosity.trim().toIntOrNull() ?: 50)
+    }
+    saving = true
+    actions.saveJsonData(apiPath, obj) { ok ->
+      saving = false
+      snack(if (ok) context.getString(R.string.saved) else context.getString(R.string.save_failed))
+    }
+  }
+
+  fun saveDns() {
+    val list = dnsResolvers.map { it.trim() }.filter { it.isNotEmpty() }
+    if (list.isEmpty()) {
+      snack(context.getString(R.string.opera_args_dns_empty_error))
+      return
+    }
+    val arr = JSONArray().also { a -> list.forEach { a.put(it) } }
+    val obj = JSONObject().put("data", arr)
+    // The API expects a plain JSON array, not a wrapped object — send array directly
+    dnsSaving = true
+    // saveJsonData wraps in JSONObject, so we use saveText with raw JSON
+    actions.saveText(dnsApiPath, arr.toString()) { ok ->
+      dnsSaving = false
+      snack(if (ok) context.getString(R.string.saved) else context.getString(R.string.save_failed))
+    }
+  }
+
+  if (!loaded) {
+    LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+    return
+  }
+
+  Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+
+    // ── Card: -api-proxy ── (highlighted as most important)
+    Card(
+      colors = CardDefaults.cardColors(
+        containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.40f)
+      )
+    ) {
+      Column(Modifier.padding(14.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+          stringResource(R.string.opera_args_api_proxy_title),
+          fontWeight = FontWeight.SemiBold,
+          style = MaterialTheme.typography.titleSmall,
+        )
+        Text(
+          stringResource(R.string.opera_args_api_proxy_desc),
+          style = MaterialTheme.typography.bodySmall,
+          color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.65f),
+        )
+        OutlinedTextField(
+          value = apiProxy,
+          onValueChange = { apiProxy = it },
+          modifier = Modifier.fillMaxWidth(),
+          singleLine = true,
+          label = { Text("-api-proxy") },
+          placeholder = { Text("socks5://host:port") },
+          keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+          isError = apiProxy.trim().isEmpty(),
+        )
+      }
+    }
+
+    // ── Card: server selection ──
+    Card {
+      Column(Modifier.padding(14.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        Text(
+          stringResource(R.string.opera_args_server_selection_title),
+          fontWeight = FontWeight.SemiBold,
+          style = MaterialTheme.typography.titleSmall,
+        )
+
+        // -server-selection chip picker
+        Text(
+          "-server-selection",
+          style = MaterialTheme.typography.labelMedium,
+          color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.75f),
+        )
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+          listOf("fastest", "random").forEach { opt ->
+            FilterChip(
+              selected = serverSelection == opt,
+              onClick = { serverSelection = opt },
+              label = { Text(opt) },
+              colors = FilterChipDefaults.filterChipColors(
+                selectedContainerColor = MaterialTheme.colorScheme.errorContainer,
+                selectedLabelColor = MaterialTheme.colorScheme.error,
+              ),
+            )
+          }
+        }
+
+        // -server-selection-dl-limit
+        OutlinedTextField(
+          value = dlLimit,
+          onValueChange = { dlLimit = it },
+          modifier = Modifier.fillMaxWidth(),
+          singleLine = true,
+          label = { Text("-server-selection-dl-limit") },
+          placeholder = { Text("204800") },
+          keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+          supportingText = { Text(stringResource(R.string.opera_args_dl_limit_hint)) },
+          isError = dlLimit.trim().toLongOrNull() == null,
+        )
+
+        // -server-selection-test-url
+        OutlinedTextField(
+          value = testUrl,
+          onValueChange = { testUrl = it },
+          modifier = Modifier.fillMaxWidth(),
+          singleLine = true,
+          label = { Text("-server-selection-test-url") },
+          placeholder = { Text("https://ajax.googleapis.com/ajax/libs/angularjs/1.8.2/angular.min.js") },
+          keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+        )
+      }
+    }
+
+    // ── Card: timing & verbosity ──
+    Card {
+      Column(Modifier.padding(14.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        Text(
+          stringResource(R.string.opera_args_misc_title),
+          fontWeight = FontWeight.SemiBold,
+          style = MaterialTheme.typography.titleSmall,
+        )
+
+        // -init-retry-interval
+        OutlinedTextField(
+          value = initRetry,
+          onValueChange = { initRetry = it },
+          modifier = Modifier.fillMaxWidth(),
+          singleLine = true,
+          label = { Text("-init-retry-interval") },
+          placeholder = { Text("3s") },
+          supportingText = { Text(stringResource(R.string.opera_args_init_retry_hint)) },
+          isError = initRetry.trim().isEmpty(),
+        )
+
+        // -verbosity
+        OutlinedTextField(
+          value = verbosity,
+          onValueChange = { verbosity = it },
+          modifier = Modifier.fillMaxWidth(),
+          singleLine = true,
+          label = { Text("-verbosity") },
+          placeholder = { Text("50") },
+          keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+          supportingText = { Text(stringResource(R.string.opera_args_verbosity_hint)) },
+          isError = verbosity.trim().toIntOrNull() == null,
+        )
+      }
+    }
+
+    // ── Card: User-Agent (advanced, collapsed visually at bottom) ──
+    Card {
+      Column(Modifier.padding(14.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+          stringResource(R.string.opera_args_ua_title),
+          fontWeight = FontWeight.SemiBold,
+          style = MaterialTheme.typography.titleSmall,
+        )
+        Text(
+          stringResource(R.string.opera_args_ua_desc),
+          style = MaterialTheme.typography.bodySmall,
+          color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.65f),
+        )
+        OutlinedTextField(
+          value = apiUserAgent,
+          onValueChange = { apiUserAgent = it },
+          modifier = Modifier.fillMaxWidth().heightIn(min = 72.dp),
+          singleLine = false,
+          maxLines = 3,
+          label = { Text("-api-user-agent") },
+        )
+      }
+    }
+
+    // ── Card: Bootstrap DNS ──
+    Card {
+      Column(Modifier.padding(14.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        Text(
+          stringResource(R.string.opera_args_bootstrap_dns_title),
+          fontWeight = FontWeight.SemiBold,
+          style = MaterialTheme.typography.titleSmall,
+        )
+        Text(
+          stringResource(R.string.opera_args_bootstrap_dns_desc),
+          style = MaterialTheme.typography.bodySmall,
+          color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.65f),
+        )
+
+        if (!dnsLoaded) {
+          LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+        } else {
+          // Existing resolver rows
+          dnsResolvers.forEachIndexed { index, resolver ->
+            Row(
+              modifier = Modifier.fillMaxWidth(),
+              verticalAlignment = Alignment.CenterVertically,
+              horizontalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+              OutlinedTextField(
+                value = resolver,
+                onValueChange = { v ->
+                  dnsResolvers = dnsResolvers.toMutableList().also { it[index] = v }
+                },
+                modifier = Modifier.weight(1f),
+                singleLine = true,
+                label = { Text(stringResource(R.string.opera_args_dns_resolver_label, index + 1)) },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+              )
+              IconButton(onClick = {
+                dnsResolvers = dnsResolvers.toMutableList().also { it.removeAt(index) }
+              }) {
+                Icon(Icons.Filled.Delete, contentDescription = stringResource(R.string.cd_delete))
+              }
+            }
+          }
+
+          // New resolver input row
+          Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+          ) {
+            OutlinedTextField(
+              value = dnsNewEntry,
+              onValueChange = { dnsNewEntry = it },
+              modifier = Modifier.weight(1f),
+              singleLine = true,
+              label = { Text(stringResource(R.string.opera_args_dns_add_label)) },
+              placeholder = { Text("https://1.1.1.1/dns-query") },
+              keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+            )
+            IconButton(
+              onClick = {
+                val trimmed = dnsNewEntry.trim()
+                if (trimmed.isNotEmpty()) {
+                  dnsResolvers = dnsResolvers + trimmed
+                  dnsNewEntry = ""
+                }
+              },
+              enabled = dnsNewEntry.trim().isNotEmpty(),
+            ) {
+              Icon(Icons.Filled.Add, contentDescription = stringResource(R.string.opera_args_dns_add_label))
+            }
+          }
+
+          // Save DNS button (separate from main args save)
+          OutlinedButton(
+            onClick = { saveDns() },
+            enabled = !dnsSaving && dnsLoaded,
+            modifier = Modifier.fillMaxWidth(),
+          ) {
+            if (dnsSaving) {
+              CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+              Spacer(Modifier.width(8.dp))
+            } else {
+              Text(stringResource(R.string.opera_args_dns_save))
+            }
+          }
+        }
+      }
+    }
+
+    // ── Save button ──
+    Button(
+      onClick = { save() },
+      enabled = !saving && loaded,
+      modifier = Modifier.fillMaxWidth(),
+    ) {
+      if (saving) {
+        CircularProgressIndicator(
+          modifier = Modifier.size(18.dp),
+          strokeWidth = 2.dp,
+        )
+      } else {
+        Text(stringResource(R.string.action_save))
+      }
+    }
+
+    Text(
+      stringResource(R.string.changes_apply_after_restart),
+      style = MaterialTheme.typography.bodySmall,
+      color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.55f),
+    )
   }
 }
 

--- a/application/app/src/main/res/values-ru/strings.xml
+++ b/application/app/src/main/res/values-ru/strings.xml
@@ -917,6 +917,22 @@
     <string name="myproxy_credentials_pair_required">Если указан логин или пароль, заполните оба поля.</string>
     <string name="myproxy_auto_save_failed">Не удалось выполнить автосохранение</string>
 
+    <string name="tab_opera_args">Аргументы</string>
+    <string name="opera_args_api_proxy_title">API Прокси (-api-proxy)</string>
+    <string name="opera_args_api_proxy_desc">SOCKS5 или HTTP прокси, через который opera-proxy авторизуется на серверах Opera.</string>
+    <string name="opera_args_server_selection_title">Выбор сервера</string>
+    <string name="opera_args_dl_limit_hint">Лимит загрузки в байтах для теста скорости серверов. По умолчанию: 204800 (200 КБ)</string>
+    <string name="opera_args_misc_title">Тайминги и логирование</string>
+    <string name="opera_args_init_retry_hint">Интервал повтора при ошибке запуска. Примеры: 3s, 5s, 10s</string>
+    <string name="opera_args_verbosity_hint">Уровень детализации логов. Выше = больше логов. По умолчанию: 50</string>
+    <string name="opera_args_ua_title">User-Agent (Дополнительно)</string>
+    <string name="opera_args_ua_desc">User-Agent, отправляемый в Opera API. Меняй только если знаешь что делаешь.</string>
+    <string name="opera_args_bootstrap_dns_title">Bootstrap DNS</string>
+    <string name="opera_args_bootstrap_dns_desc">DNS-резолверы, используемые opera-proxy для разрешения адресов серверов Opera. Локальный dnscrypt (если включён) всегда добавляется первым автоматически.</string>
+    <string name="opera_args_dns_resolver_label">Резолвер %1$d</string>
+    <string name="opera_args_dns_add_label">Добавить резолвер</string>
+    <string name="opera_args_dns_save">Сохранить список DNS</string>
+    <string name="opera_args_dns_empty_error">Список резолверов не может быть пустым</string>
 
     <string name="apps_list_desc_myprogram">Профильный запуск пользовательской команды с необязательным app mode и t2s</string>
     <string name="apps_conflict_program_myprogram">myprogram</string>

--- a/application/app/src/main/res/values/strings.xml
+++ b/application/app/src/main/res/values/strings.xml
@@ -919,6 +919,22 @@ Protection does not work in hotspot mode. If hotspot is enabled and sing-box is 
     <string name="myproxy_credentials_pair_required">If username or password is used, fill in both fields.</string>
     <string name="myproxy_auto_save_failed">Failed to auto-save changes</string>
 
+    <string name="tab_opera_args">Args</string>
+    <string name="opera_args_api_proxy_title">API Proxy (-api-proxy)</string>
+    <string name="opera_args_api_proxy_desc">SOCKS5 or HTTP proxy used by opera-proxy to reach Opera backend API. This is the most frequently changed argument.</string>
+    <string name="opera_args_server_selection_title">Server Selection</string>
+    <string name="opera_args_dl_limit_hint">Download limit in bytes for server speed test. Default: 204800 (200 KB)</string>
+    <string name="opera_args_misc_title">Timing &amp; Verbosity</string>
+    <string name="opera_args_init_retry_hint">Retry interval on startup failure. Examples: 3s, 5s, 10s</string>
+    <string name="opera_args_verbosity_hint">Log verbosity level. Higher = more logs. Default: 50</string>
+    <string name="opera_args_ua_title">User-Agent (Advanced)</string>
+    <string name="opera_args_ua_desc">User-Agent sent to Opera API. Change only if you know what you are doing.</string>
+    <string name="opera_args_bootstrap_dns_title">Bootstrap DNS</string>
+    <string name="opera_args_bootstrap_dns_desc">DNS resolvers used by opera-proxy to resolve Opera server addresses. The local dnscrypt resolver (if enabled) is always prepended automatically.</string>
+    <string name="opera_args_dns_resolver_label">Resolver %1$d</string>
+    <string name="opera_args_dns_add_label">Add resolver</string>
+    <string name="opera_args_dns_save">Save DNS list</string>
+    <string name="opera_args_dns_empty_error">Resolver list must not be empty</string>
 
     <string name="apps_list_desc_myprogram">Profile-based launcher with optional app mode and t2s</string>
     <string name="apps_conflict_program_myprogram">myprogram</string>

--- a/module_template/working_folder/operaproxy/config/args.json
+++ b/module_template/working_folder/operaproxy/config/args.json
@@ -1,0 +1,9 @@
+{
+  "api_proxy": "socks5://193.221.203.192:1080",
+  "api_user_agent": "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Mobile Safari/537.36 OPR/98.0.0.0",
+  "init_retry_interval": "3s",
+  "server_selection": "fastest",
+  "server_selection_dl_limit": 204800,
+  "server_selection_test_url": "https://ajax.googleapis.com/ajax/libs/angularjs/1.8.2/angular.min.js",
+  "verbosity": 50
+}

--- a/module_template/working_folder/operaproxy/config/bootstrap_dns.json
+++ b/module_template/working_folder/operaproxy/config/bootstrap_dns.json
@@ -1,0 +1,12 @@
+[
+    "https://xbox-dns.ru/dns-query",
+    "tls://9.9.9.9:853",
+    "https://ru-mow.doh.sb/dns-query",
+    "https://1.1.1.3/dns-query",
+    "https://security.cloudflare-dns.com/dns-query",
+    "https://wikimedia-dns.org/dns-query",
+    "https://dns.adguard-dns.com/dns-query",
+    "https://dns.quad9.net/dns-query",
+    "https://dns.comss.one/dns-query",
+    "https://router.comss.one/dns-query"
+]

--- a/rust/zdtd/src/api.rs
+++ b/rust/zdtd/src/api.rs
@@ -3660,6 +3660,72 @@ fn handle_programs_subroutes(stream: TcpStream, method: &str, path: &str, header
             }
         }
 
+        // --- operaproxy args (config/args.json) ---
+        ("GET", ["api", "programs", "operaproxy", "args"]) => {
+            let args = crate::programs::operaproxy::read_opera_args();
+            match serde_json::to_value(&args) {
+                Ok(v) => write_json(stream, 200, json!({"ok": true, "data": v})),
+                Err(e) => write_err(stream, anyhow::anyhow!("serialize args: {e}")),
+            }
+        }
+        ("PUT", ["api", "programs", "operaproxy", "args"]) => {
+            let res = (|| -> Result<()> {
+                let args: crate::programs::operaproxy::OperaArgs =
+                    serde_json::from_slice(body)
+                        .map_err(|e| anyhow::anyhow!("bad JSON body: {e}"))?;
+                // Basic sanity checks
+                if args.api_proxy.trim().is_empty() {
+                    anyhow::bail!("api_proxy must not be empty");
+                }
+                if args.init_retry_interval.trim().is_empty() {
+                    anyhow::bail!("init_retry_interval must not be empty");
+                }
+                if args.server_selection.trim().is_empty() {
+                    anyhow::bail!("server_selection must not be empty");
+                }
+                if args.server_selection_test_url.trim().is_empty() {
+                    anyhow::bail!("server_selection_test_url must not be empty");
+                }
+                crate::programs::operaproxy::write_opera_args(&args)?;
+                Ok(())
+            })();
+            match res {
+                Ok(_) => write_ok(stream),
+                Err(e) => write_err(stream, e),
+            }
+        }
+
+        // --- operaproxy bootstrap DNS (config/bootstrap_dns.json) ---
+        ("GET", ["api", "programs", "operaproxy", "bootstrap_dns"]) => {
+            let resolvers = crate::programs::operaproxy::read_bootstrap_dns();
+            // Return as JSON array split on comma for easy UI consumption
+            let arr: serde_json::Value = resolvers
+                .split(',')
+                .map(|s| serde_json::Value::String(s.trim().to_string()))
+                .collect::<Vec<_>>()
+                .into();
+            write_json(stream, 200, json!({"ok": true, "data": arr}))
+        }
+        ("PUT", ["api", "programs", "operaproxy", "bootstrap_dns"]) => {
+            let res = (|| -> Result<()> {
+                let arr: Vec<String> = serde_json::from_slice(body)
+                    .map_err(|e| anyhow::anyhow!("bad JSON body (expected array of strings): {e}"))?;
+                let clean: Vec<String> = arr.iter()
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect();
+                if clean.is_empty() {
+                    anyhow::bail!("resolver list must not be empty");
+                }
+                crate::programs::operaproxy::write_bootstrap_dns(&clean)?;
+                Ok(())
+            })();
+            match res {
+                Ok(_) => write_ok(stream),
+                Err(e) => write_err(stream, e),
+            }
+        }
+
         // --- legacy sing-box routes kept only to explain migration
         ("GET", ["api", "programs", "sing-box", "setting"]) | ("PUT", ["api", "programs", "sing-box", "setting"]) => {
             write_json(stream, 200, json!({

--- a/rust/zdtd/src/programs/operaproxy.rs
+++ b/rust/zdtd/src/programs/operaproxy.rs
@@ -692,6 +692,8 @@ fn spawn_opera_proxy(
     cmd.arg("-bind-address")
         .arg(bind)
         .arg("-socks-mode")
+        .arg("-cafile")
+        .arg(OPERA_CAFILE)
         .arg("-fake-SNI")
         .arg(fake_sni)
         .arg("-bootstrap-dns")

--- a/rust/zdtd/src/programs/operaproxy.rs
+++ b/rust/zdtd/src/programs/operaproxy.rs
@@ -36,6 +36,17 @@ const IPT_TIMEOUT: Duration = Duration::from_secs(5);
 // Opera-proxy CA bundle for certificate verification. We keep it fixed to prevent config tampering.
 const OPERA_CAFILE: &str = "/data/adb/modules/ZDT-D/strategic/certificate/ca.bundle";
 
+// Configurable opera-proxy arguments stored as JSON (editable from the app UI).
+const OPERA_ARGS_JSON: &str =
+    "/data/adb/modules/ZDT-D/working_folder/operaproxy/config/args.json";
+
+// Configurable bootstrap DNS resolvers stored as a JSON array of strings (editable from the app UI).
+const BOOTSTRAP_DNS_JSON: &str =
+    "/data/adb/modules/ZDT-D/working_folder/operaproxy/config/bootstrap_dns.json";
+
+// Built-in fallback bootstrap DNS resolvers used when bootstrap_dns.json is missing or empty.
+const DEFAULT_BOOTSTRAP_DNS: &str = "tls://dns.geohide.ru,https://xbox-dns.ru/dns-query,tls://9.9.9.9:853,https://ru-mow.doh.sb/dns-query,https://1.1.1.3/dns-query,https://security.cloudflare-dns.com/dns-query,https://wikimedia-dns.org/dns-query,https://dns.adguard-dns.com/dns-query,https://dns.quad9.net/dns-query,https://dns.comss.one/dns-query,https://router.comss.one/dns-query";
+
 const APP_UID_USER: &str =
     "/data/adb/modules/ZDT-D/working_folder/operaproxy/app/uid/user_program";
 const APP_OUT_USER: &str =
@@ -78,6 +89,119 @@ struct PortJson {
     iface_mobile: String,
     #[serde(default = "default_iface")]
     iface_wifi: String,
+}
+
+/// Configurable opera-proxy arguments.
+/// All fields correspond directly to opera-proxy CLI flags.
+/// Stored in config/args.json and edited from the app UI.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OperaArgs {
+    /// -api-proxy: SOCKS5/HTTP proxy used by opera-proxy to reach Opera backend API.
+    /// Example: "socks5://193.221.203.192:1080"
+    #[serde(default = "default_api_proxy")]
+    pub api_proxy: String,
+
+    /// -api-user-agent: User-Agent sent to Opera backend API.
+    #[serde(default = "default_api_user_agent")]
+    pub api_user_agent: String,
+
+    /// -init-retry-interval: retry interval on startup failure. Example: "3s", "5s".
+    #[serde(default = "default_init_retry_interval")]
+    pub init_retry_interval: String,
+
+    /// -server-selection: strategy for choosing the fastest server.
+    /// Typical values: "fastest", "random".
+    #[serde(default = "default_server_selection")]
+    pub server_selection: String,
+
+    /// -server-selection-dl-limit: download limit in bytes for speed test. Example: 204800.
+    #[serde(default = "default_server_selection_dl_limit")]
+    pub server_selection_dl_limit: u64,
+
+    /// -server-selection-test-url: URL used for the speed test.
+    #[serde(default = "default_server_selection_test_url")]
+    pub server_selection_test_url: String,
+
+    /// -verbosity: logging verbosity level (integer). Default: 50.
+    #[serde(default = "default_verbosity")]
+    pub verbosity: u32,
+}
+
+// ---- Default value functions required by serde ----
+
+fn default_api_proxy() -> String {
+    "socks5://193.221.203.192:1080".to_string()
+}
+
+fn default_api_user_agent() -> String {
+    "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Mobile Safari/537.36 OPR/98.0.0.0".to_string()
+}
+
+fn default_init_retry_interval() -> String {
+    "3s".to_string()
+}
+
+fn default_server_selection() -> String {
+    "fastest".to_string()
+}
+
+fn default_server_selection_dl_limit() -> u64 {
+    204800
+}
+
+fn default_server_selection_test_url() -> String {
+    "https://ajax.googleapis.com/ajax/libs/angularjs/1.8.2/angular.min.js".to_string()
+}
+
+fn default_verbosity() -> u32 {
+    50
+}
+
+impl Default for OperaArgs {
+    fn default() -> Self {
+        Self {
+            api_proxy: default_api_proxy(),
+            api_user_agent: default_api_user_agent(),
+            init_retry_interval: default_init_retry_interval(),
+            server_selection: default_server_selection(),
+            server_selection_dl_limit: default_server_selection_dl_limit(),
+            server_selection_test_url: default_server_selection_test_url(),
+            verbosity: default_verbosity(),
+        }
+    }
+}
+
+/// Load configurable opera-proxy arguments from config/args.json.
+/// If the file is missing or unparseable, returns built-in defaults.
+pub fn read_opera_args() -> OperaArgs {
+    let path = Path::new(OPERA_ARGS_JSON);
+    if !path.is_file() {
+        return OperaArgs::default();
+    }
+    match fs::read_to_string(path) {
+        Ok(s) => serde_json::from_str::<OperaArgs>(&s).unwrap_or_else(|e| {
+            warn!("operaproxy: failed to parse args.json: {} -> using defaults", e);
+            OperaArgs::default()
+        }),
+        Err(e) => {
+            warn!("operaproxy: failed to read args.json: {} -> using defaults", e);
+            OperaArgs::default()
+        }
+    }
+}
+
+/// Write configurable opera-proxy arguments to config/args.json.
+pub fn write_opera_args(args: &OperaArgs) -> Result<()> {
+    let path = Path::new(OPERA_ARGS_JSON);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("mkdir {}", parent.display()))?;
+    }
+    let json = serde_json::to_string_pretty(args)
+        .with_context(|| "serialize OperaArgs")?;
+    fs::write(path, json.as_bytes())
+        .with_context(|| format!("write {}", path.display()))?;
+    Ok(())
 }
 
 
@@ -166,6 +290,16 @@ pub fn start_if_enabled() -> Result<()> {
     // opera-proxy region (EU/AS/AM) from config/server.txt, validated against whitelist
     let country = read_server_region(Path::new(SERVER_TXT));
 
+    // Load configurable opera-proxy args (falls back to defaults if file missing/invalid)
+    let opera_args = read_opera_args();
+    info!(
+        "operaproxy: args loaded: api_proxy='{}' verbosity={} server_selection='{}' init_retry='{}'",
+        opera_args.api_proxy,
+        opera_args.verbosity,
+        opera_args.server_selection,
+        opera_args.init_retry_interval,
+    );
+
     let service_count = sni_list.len();
     let any_uses_byedpi = sni_list.iter().any(|x| x.use_byedpi);
 
@@ -225,6 +359,7 @@ pub fn start_if_enabled() -> Result<()> {
             entry.override_proxy_address.as_deref(),
             &country,
             &bootstrap_dns,
+            &opera_args,
             &log_path,
         )?;
 
@@ -336,15 +471,59 @@ pub fn start_if_enabled() -> Result<()> {
     Ok(())
 }
 
+/// Read the bootstrap DNS resolver list from config/bootstrap_dns.json.
+/// Returns a comma-separated string of resolver URLs.
+/// Falls back to DEFAULT_BOOTSTRAP_DNS if the file is missing, empty, or invalid.
+pub fn read_bootstrap_dns() -> String {
+    let path = Path::new(BOOTSTRAP_DNS_JSON);
+    if !path.is_file() {
+        return DEFAULT_BOOTSTRAP_DNS.to_string();
+    }
+    let s = match fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) => {
+            warn!("operaproxy: failed to read bootstrap_dns.json: {} -> using defaults", e);
+            return DEFAULT_BOOTSTRAP_DNS.to_string();
+        }
+    };
+    // Parse as JSON array of strings
+    let arr: Vec<String> = match serde_json::from_str::<Vec<String>>(&s) {
+        Ok(v) => v.into_iter().map(|e| e.trim().to_string()).filter(|e| !e.is_empty()).collect(),
+        Err(e) => {
+            warn!("operaproxy: failed to parse bootstrap_dns.json: {} -> using defaults", e);
+            return DEFAULT_BOOTSTRAP_DNS.to_string();
+        }
+    };
+    if arr.is_empty() {
+        warn!("operaproxy: bootstrap_dns.json is empty -> using defaults");
+        return DEFAULT_BOOTSTRAP_DNS.to_string();
+    }
+    arr.join(",")
+}
+
+/// Write bootstrap DNS resolver list to config/bootstrap_dns.json as a JSON array.
+pub fn write_bootstrap_dns(resolvers: &[String]) -> Result<()> {
+    let path = Path::new(BOOTSTRAP_DNS_JSON);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("mkdir {}", parent.display()))?;
+    }
+    let json = serde_json::to_string_pretty(resolvers)
+        .with_context(|| "serialize bootstrap DNS list")?;
+    fs::write(path, json.as_bytes())
+        .with_context(|| format!("write {}", path.display()))?;
+    Ok(())
+}
+
 fn build_bootstrap_dns_list() -> Result<String> {
-    // External resolvers (do not shorten)
-    let external = "https://1.1.1.1/dns-query,tls://9.9.9.9:853,https://1.1.1.3/dns-query,https://8.8.8.8/dns-query,https://dns.google/dns-query,https://security.cloudflare-dns.com/dns-query,https://fidelity.vm-0.com/q,https://wikimedia-dns.org/dns-query,https://dns.adguard-dns.com/dns-query,https://dns.quad9.net/dns-query,https://doh.cleanbrowsing.org/doh/adult-filter/";
-    // Add local dnscrypt only if enabled
+    // Load configurable external resolvers (falls back to defaults if file missing/invalid)
+    let external = read_bootstrap_dns();
+    // Prepend local dnscrypt resolver if it is currently enabled
     if let Some(port) = dnscrypt::active_listen_port()? {
         let local = format!("https://127.0.0.1:{},{}", port, external);
         Ok(local)
     } else {
-        Ok(external.to_string())
+        Ok(external)
     }
 }
 
@@ -495,6 +674,7 @@ fn spawn_opera_proxy(
     override_proxy_address: Option<&str>,
     country: &str,
     bootstrap_dns: &str,
+    opera_args: &OperaArgs,
     log_path: &Path,
 ) -> Result<()> {
     let logf = OpenOptions::new()
@@ -512,23 +692,26 @@ fn spawn_opera_proxy(
     cmd.arg("-bind-address")
         .arg(bind)
         .arg("-socks-mode")
-        .arg("-cafile")
-        .arg(OPERA_CAFILE)
         .arg("-fake-SNI")
         .arg(fake_sni)
         .arg("-bootstrap-dns")
         .arg(bootstrap_dns)
         .arg("-api-user-agent")
-        .arg("Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Mobile Safari/537.36")
-        .arg("-certchain-workaround")
+        .arg(&opera_args.api_user_agent)
         .arg("-country")
         .arg(country)
         .arg("-init-retry-interval")
-        .arg("3s")
+        .arg(&opera_args.init_retry_interval)
         .arg("-server-selection")
-        .arg("fastest")
+        .arg(&opera_args.server_selection)
         .arg("-server-selection-dl-limit")
-        .arg("204800");
+        .arg(opera_args.server_selection_dl_limit.to_string())
+        .arg("-verbosity")
+        .arg(opera_args.verbosity.to_string())
+        .arg("-api-proxy")
+        .arg(&opera_args.api_proxy)
+        .arg("-server-selection-test-url")
+        .arg(&opera_args.server_selection_test_url);
     if let Some(ref upstream) = upstream {
         cmd.arg("-proxy").arg(upstream);
     }


### PR DESCRIPTION
Так как Opera ограничила доступ к своим серверам из России, что бы было проще, решил перенести hardcode аргументы в настройки модуля внутри софта (допустим, для быстрого изменения аргумента api-proxy).
Так же, обновлен бинарник, за что большое спасибо SLY-F0X (https://github.com/SLY-F0X/opera-proxy-android-wrapper/releases/tag/3%2C0%2C20_alpha).