### PR TITLE
AI polish: simplify SingBox snackbar helper

### DIFF
--- a/application/app/src/main/java/com/android/zdtd/service/ui/SingBoxProfileScreen.kt
+++ b/application/app/src/main/java/com/android/zdtd/service/ui/SingBoxProfileScreen.kt
@@ -211,6 +211,13 @@ private suspend fun isSingBoxWebPanelPortOpen(port: Int): Boolean = withContext(
   }.getOrDefault(false)
 }
 
+private fun createSnackFunction(
+  scope: kotlinx.coroutines.CoroutineScope,
+  snackHost: SnackbarHostState,
+): (String) -> Unit = { msg ->
+  scope.launch { snackHost.showSnackbar(msg) }
+}
+
 @Composable
 private fun SingBoxSectionCard(
   title: String,
@@ -1982,9 +1989,7 @@ private fun SingBoxCreateServerDialog(
   var error by remember { mutableStateOf<String?>(null) }
   val name = remember(raw) { normalizeSingBoxServerName(raw) }
 
-  fun snack(msg: String) {
-    scope.launch { snackHost.showSnackbar(msg) }
-  }
+  val snack = createSnackFunction(scope, snackHost)
 
   Dialog(
     onDismissRequest = onDismiss,
@@ -2111,9 +2116,7 @@ private fun SingBoxImportToProfileDialog(
   var error by remember { mutableStateOf<String?>(null) }
   val name = remember(raw) { normalizeSingBoxServerName(raw) }
 
-  fun snack(msg: String) {
-    scope.launch { snackHost.showSnackbar(msg) }
-  }
+  val snack = createSnackFunction(scope, snackHost)
 
   Dialog(
     onDismissRequest = onDismiss,


### PR DESCRIPTION
Conservative AI-assisted polish.

Changes:
- Extracts repeated SingBox snackbar helper logic.
- Keeps behavior unchanged.
- Does not touch routing, release workflow, service-build logic, NFQUEUE, Zygisk, prebuilt files, or architecture.

Review manually before merge.