### PR TITLE
Removed the Lines of Code badge from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,6 @@
   <a href="https://github.com/GAME-OVER-op/ZDT-D/commits/main">
     <img src="https://img.shields.io/github/last-commit/GAME-OVER-op/ZDT-D?style=flat-square" alt="Last Commit" />
   </a>
-  <a href="https://tokei.kojix2.net/github/GAME-OVER-op/ZDT-D">
-   <img src="https://img.shields.io/endpoint?url=https%3A%2F%2Ftokei.kojix2.net%2Fbadge%2Fgithub%2FGAME-OVER-op%2FZDT-D%2Flines&style=flat-square&logo=github" alt="Lines of Code" />
-  </a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Hello.

I am kojix2, the maintainer of tokei-api.

The tokei-api badge seems to be broken for this repository.

tokei-api is a small personal service that I run as a hobby. 
While checking the logs, I noticed that requests for `GAME-OVER-op/ZDT-D` repeatedly exceed the time limit and time out.
This might be because the repository contains large prebuilt binaries.

I am sorry, but I cannot make the badge work reliably for this repository.
I would appreciate it if the badge could be removed.
Sorry about this :crying_cat_face: 